### PR TITLE
Log request parsing errors for produce request

### DIFF
--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -179,7 +179,7 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 	// Get the message body from the HTTP request.
 	var msg sarama.Encoder
 	if msg, err = s.readMsg(r); err != nil {
-		log.Errorf("Failed to get HTTP message body for produce request: err=(%s)", err)
+		log.Warnf("Failed to get HTTP message body for produce request: err=(%s)", err)
 		s.respondWithJSON(w, http.StatusBadRequest, errorRs{err.Error()})
 		return
 	}

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -179,7 +179,7 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 	// Get the message body from the HTTP request.
 	var msg sarama.Encoder
 	if msg, err = s.readMsg(r); err != nil {
-		log.Warnf("Failed to get HTTP message body for produce request: err=(%s)", err)
+		log.Infof("Rejecting HTTP message body for produce request from %s: err=(%s)", r.RemoteAddr, err)
 		s.respondWithJSON(w, http.StatusBadRequest, errorRs{err.Error()})
 		return
 	}

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mailgun/kafka-pixy/prettyfmt"
 	"github.com/mailgun/kafka-pixy/proxy"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -178,6 +179,7 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 	// Get the message body from the HTTP request.
 	var msg sarama.Encoder
 	if msg, err = s.readMsg(r); err != nil {
+		log.Errorf("Failed to get HTTP message body for produce request: err=(%s)", err)
 		s.respondWithJSON(w, http.StatusBadRequest, errorRs{err.Error()})
 		return
 	}

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -68,7 +68,7 @@ type T struct {
 
 func init() {
 	var err error
-	if jsonContentTypePattern, err = regexp.Compile("^application/(?:.*\\+)?json$"); err != nil {
+	if jsonContentTypePattern, err = regexp.Compile("^application/(?:.*\\+)?json(?:;.*)?$"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
We're using Pixy as webhook target for 3rd party services like [Docker Registry](https://docs.docker.com/registry/notifications/). Some senders don't print error responses. In the case of Docker Registry we see "400 Bad Request unaccepted" (maybe it only prints the first word of the response). 